### PR TITLE
Add model hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jerein
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
 
 l create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/jereinhardt/feste.
-
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ mount Feste::Engine => "/email-subscriptions", as: "feste"
 
 ## Configuration
 
-Feste organizes subscribable emails by separating them into categories that you define (see `Mailer` for more details).  This requires an array of available category names to be provided to the `categories` configuration. One configuration that is required for this is for you to provide an array listing all available category names.
+Feste organizes subscribable emails by separating them into categories that you define (see <a href="#mailer">Mailer</a> for more details).  This requires an array of available category names to be provided to the `categories` configuration.
 
 Out of the box, Feste allows your users to manage their subscriptions from a url in their email, which includes an identifying token.  If you would like for them to be able to do so from within your application, you will need to provide a method for identifying the currently logged in user.  Luckily, Feste provides authentication adapters for applications that use Devise and Clearance to manage user sessions.  Otherwise, you can provide a Proc to the `authenticate_with` option.
 
-Optionally, you can set the attribute your user model uses to reference your user's email address (`email_source`), the host is used by the `subscriptions_url` helper (`host`).
+Optionally, you can set the attribute your user model(s) use(s) to reference a user's email address (`email_source`) and the host that is used by the `subscriptions_url` helper (`host`).  If you have multiple databse tables that store email addresses, and might have duplicates between them, you can provide the `model_hierarchy` option with an array of model classes, arranged from highest to lowest priorty (See <a href="#mailer">Model</a> for more details.)
 
 ```ruby
 # initializers/feste.rb
@@ -48,6 +48,8 @@ Feste.configure do |config|
   config.email_source = :email
   # set the host for subscription_url
   config.host = ActionMailer::Base.default_url_options[:host]
+  # set a priorty hierarchy of models that might share email addresses
+  config.model_hierarchy = nil
 end
 ```
 ## Usage
@@ -62,7 +64,9 @@ class User < ApplicationRecord
 end
 ```
 
-This will give your user model a `has_many` relationship to `subscriptions`.  Since this relationship is polymorphic, your can include the `Feste::User` module in multiple models.
+This will give your user model a `has_many` relationship to `subscriptions`.  Since this relationship is polymorphic, your can include the `Feste::User` module in multiple models.  
+
+Please note that if you use multiple database tables to house user data, and different tables have duplicate email addresses between them, this may cause issues when Feste tries to find a record based on an email address.  This issue can be avoided by creating an array of model classes arranged in the order Feste should look for a record, with the highest priority model first (i.e. `[User, Lead, Inquirer]`).  Assign this array as the value of the `model_hierarchy` configuration option (see <a href="#configuration">Configuration</a> for more).
 
 ### Mailer
 

--- a/app/models/feste/subscription.rb
+++ b/app/models/feste/subscription.rb
@@ -32,7 +32,7 @@ module Feste
       ActiveRecord::Base.descendants.select do |klass|
         klass.included_modules.include?(Feste::User)
       end
-    end 
+    end
 
     def generate_token
       if !self.token

--- a/app/models/feste/subscription.rb
+++ b/app/models/feste/subscription.rb
@@ -25,10 +25,14 @@ module Feste
     private
 
     def self.user_models
-      @_user_models ||= ActiveRecord::Base.descendants.select do |klass|
+      @_user_models ||= Feste.options[:model_hierarchy] || included_models
+    end
+
+    def self.included_models
+      ActiveRecord::Base.descendants.select do |klass|
         klass.included_modules.include?(Feste::User)
       end
-    end
+    end 
 
     def generate_token
       if !self.token

--- a/lib/feste.rb
+++ b/lib/feste.rb
@@ -21,7 +21,8 @@ module Feste
     categories: [],
     host: nil,
     email_source: :email,
-    authenticate_with: nil
+    authenticate_with: nil,
+    model_hierarchy: nil
   }
 
   def self.configure


### PR DESCRIPTION
This PR gives developers a way to avoid model ambiguity when looking for a subscriber based on email address.