### PR TITLE
Explicitly state subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Feste organizes subscribable emails by separating them into categories that you 
 
 Out of the box, Feste allows your users to manage their subscriptions from a url in their email, which includes an identifying token.  If you would like for them to be able to do so from within your application, you will need to provide a method for identifying the currently logged in user.  Luckily, Feste provides authentication adapters for applications that use Devise and Clearance to manage user sessions.  Otherwise, you can provide a Proc to the `authenticate_with` option.
 
-Optionally, you can set the attribute your user model(s) use(s) to reference a user's email address (`email_source`) and the host that is used by the `subscriptions_url` helper (`host`).  If you have multiple databse tables that store email addresses, and might have duplicates between them, you can provide the `model_hierarchy` option with an array of model classes, arranged from highest to lowest priorty (See <a href="#mailer">Model</a> for more details.)
+Optionally, you can set the attribute your user model(s) use(s) to reference a user's email address (`email_source`) and the host that is used by the `subscriptions_url` helper (`host`).
 
 ```ruby
 # initializers/feste.rb
@@ -48,8 +48,6 @@ Feste.configure do |config|
   config.email_source = :email
   # set the host for subscription_url
   config.host = ActionMailer::Base.default_url_options[:host]
-  # set a priorty hierarchy of models that might share email addresses
-  config.model_hierarchy = nil
 end
 ```
 ## Usage
@@ -66,13 +64,13 @@ end
 
 This will give your user model a `has_many` relationship to `subscriptions`.  Since this relationship is polymorphic, your can include the `Feste::User` module in multiple models.  
 
-Please note that if you use multiple database tables to house user data, and different tables have duplicate email addresses between them, this may cause issues when Feste tries to find a record based on an email address.  This issue can be avoided by creating an array of model classes arranged in the order Feste should look for a record, with the highest priority model first (i.e. `[User, Lead, Inquirer]`).  Assign this array as the value of the `model_hierarchy` configuration option (see <a href="#configuration">Configuration</a> for more).
-
 ### Mailer
 
 In your mailer, include the `Feste::Mailer` module.
 
 Feste keeps track of email subscriptions by grouping mailer actions into categories that you define.  Your users will not be able to subscribe or unsubscribe to emails until you assign specific actions to a category.  In order to do this, you can call the `categorize` method within your mailer.  Doing so will automatically assign all actions in that mailer to the category you provide through the `as` option.
+
+When calling the `mail` method within an action, make sure to explicitly state which user the subscription should be applied to using the `subscriber` option.
 
 ```ruby
 class CouponMailer < ApplicationMailer
@@ -81,7 +79,7 @@ class CouponMailer < ApplicationMailer
   categorize as: "Marketing Emails"
 
   def send_coupon(user)
-    mail(to: user.email, from: "support@here.com")
+    mail(to: user.email, from: "support@here.com", subscriber: user)
   end
 end
 ```
@@ -96,11 +94,11 @@ class CouponMailer < ApplicationMailer
   categorize [:send_coupon_reminder], as: "Reminder Emails"
 
   def send_coupon(user)
-    mail(to: user.email, from: "support@here.com")
+    mail(to: user.email, from: "support@here.com", subscriber: user)
   end
 
   def send_coupon_reminder(user)
-    mail(to: user.email, from: "support@here.com")
+    mail(to: user.email, from: "support@here.com", subscriber: user)
   end
 end
 ```

--- a/app/models/feste/subscription.rb
+++ b/app/models/feste/subscription.rb
@@ -25,10 +25,6 @@ module Feste
     private
 
     def self.user_models
-      @_user_models ||= Feste.options[:model_hierarchy] || included_models
-    end
-
-    def self.included_models
       ActiveRecord::Base.descendants.select do |klass|
         klass.included_modules.include?(Feste::User)
       end

--- a/lib/feste/mailer.rb
+++ b/lib/feste/mailer.rb
@@ -12,45 +12,47 @@ module Feste
 
     module InstanceMethods
       def mail(headers = {}, &block)
-        return message if @_mail_was_called && headers.blank? && !block
+        if process_current_action?
+          return message if @_mail_was_called && headers.blank? && !block
 
-        email = headers[:to].is_a?(String) ? headers[:to] : headers[:to].first
-        subscriber = Feste::Subscription.find_subscribed_user(email)
+          email = headers[:to].is_a?(String) ? headers[:to] : headers[:to].first
+          subscriber = headers[:subscriber] ||
+            Feste::Subscription.find_subscribed_user(email)
+          headers = headers.except(:subscriber)
 
-        if recipient_subscribed?(subscriber)
-          generate_subscription_token!(subscriber)
-          message = super
+          if recipient_subscribed?(subscriber)
+            generate_subscription_token!(subscriber)
+            message = super(headers, &block)
+          else
+            nil
+          end          
         else
-          nil
+          super(headers, &block)
         end
       end
 
       private
 
-      def generate_subscription_token!(subscriber)
-        if process_email_subscription?(subscriber)
-          @_subscription_token ||= Feste::Subscription.
-            get_token_for(subscriber, self, action_name)
-        end
+      def process_current_action?
+        self.action_categories[action_name.to_sym] || 
+          self.action_categories[:all]
       end
 
-      def process_email_subscription?(subscriber)
-        subscriber.present? && (
-          self.action_categories[action_name.to_sym] ||
-            self.action_categories[:all]
-        )
+      def generate_subscription_token!(subscriber)
+        @_subscription_token ||= Feste::Subscription.
+          get_token_for(subscriber, self, action_name)
       end
 
       def recipient_subscribed?(subscriber)
-        category = self.action_categories[action_name.to_sym] || 
-          self.action_categories[:all]
-        if subscriber.present? && category.present?
+        if subscriber.present?
+          category = self.action_categories[action_name.to_sym] ||
+            self.action_categories[:all]
           !Feste::Subscription.find_or_create_by(
             category: category,
             subscriber: subscriber
           ).canceled?
         else
-          true
+          false
         end
       end
     end

--- a/lib/feste/mailer.rb
+++ b/lib/feste/mailer.rb
@@ -12,7 +12,7 @@ module Feste
 
     module InstanceMethods
       def mail(headers = {}, &block)
-        if process_current_action?
+        if current_action_category.present?
           return message if @_mail_was_called && headers.blank? && !block
 
           email = headers[:to].is_a?(String) ? headers[:to] : headers[:to].first
@@ -33,7 +33,7 @@ module Feste
 
       private
 
-      def process_current_action?
+      def current_action_category
         self.action_categories[action_name.to_sym] || 
           self.action_categories[:all]
       end
@@ -44,16 +44,10 @@ module Feste
       end
 
       def recipient_subscribed?(subscriber)
-        if subscriber.present?
-          category = self.action_categories[action_name.to_sym] ||
-            self.action_categories[:all]
-          !Feste::Subscription.find_or_create_by(
-            category: category,
-            subscriber: subscriber
-          ).canceled?
-        else
-          false
-        end
+        !Feste::Subscription.find_or_create_by(
+          category: current_action_category,
+          subscriber: subscriber
+        )&.canceled?
       end
     end
 

--- a/spec/dummy/app/mailers/marketing_mailer.rb
+++ b/spec/dummy/app/mailers/marketing_mailer.rb
@@ -4,14 +4,14 @@ class MarketingMailer < ApplicationMailer
   categorize as: "Marketing Emails"
 
   def send_newsletter(user)
-    mail(to: user.email, from: "support@app.com")
+    mail(to: user.email, from: "support@app.com", subscriber: user)
   end
 
   def send_coupon_list(user)
-    mail(to: user.email, from: "support@app.com")
+    mail(to: user.email, from: "support@app.com", subscriber: user)
   end
 
   def send_offer(user)
-    mail(to: user.email, from: "support@app.com")
+    mail(to: user.email, from: "support@app.com", subscriber: user)
   end
 end

--- a/spec/dummy/app/mailers/outreach_mailer.rb
+++ b/spec/dummy/app/mailers/outreach_mailer.rb
@@ -4,6 +4,6 @@ class OutreachMailer < ApplicationMailer
   categorize as: "Outreach Emails"
 
   def request_donation(user)
-    mail(to: user.email, from: "support@app.com")
+    mail(to: user.email, from: "support@app.com", subscriber: user)
   end
 end

--- a/spec/dummy/app/mailers/reminder_mailer.rb
+++ b/spec/dummy/app/mailers/reminder_mailer.rb
@@ -4,10 +4,10 @@ class ReminderMailer < ApplicationMailer
   categorize as: "Reminder Emails"
 
   def send_reminder(user)
-    mail(to: user.email, from: "support@app.com")
+    mail(to: user.email, from: "support@app.com", subscriber: user)
   end
 
   def send_email_confimation_reminder(user)
-    mail(to: user.email, from: "support@app.com")
+    mail(to: user.email, from: "support@app.com", subscriber: user)
   end
 end

--- a/spec/support/main_mailer.rb
+++ b/spec/support/main_mailer.rb
@@ -4,14 +4,29 @@ class MainMailer < ActionMailer::Base
   categorize [:send_mail, :send_more_mail], as: "Marketing Emails"
 
   def send_mail(user)
-    mail(to: user.email, from: "support@email", subject: "subject")
+    mail(
+      to: user.email,
+      from: "support@email",
+      subject: "subject",
+      subscriber: user
+    )
   end
 
   def send_more_mail(user)
-    mail(to: user.email, from: "support@email", subject: "subject")
+    mail(
+      to: user.email,
+      from: "support@email",
+      subject: "subject",
+      subscriber: user
+    )
   end
 
   def send_less_mail(user)
-    mail(to: user.email, from: "support@email", subject: "subject")
+    mail(
+      to: user.email,
+      from: "support@email",
+      subject: "subject",
+      subscriber: user
+    )
   end
 end


### PR DESCRIPTION
This PR changes how a potentially ambiguous subscriber is selected by asking for the developer to explicitly state which model instance the subscription is to be applied to (retains previous method of searching classes with the `Feste::User` module as a fallback. 