### PR TITLE
Make category names more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ mount Feste::Engine => "/email-subscriptions", as: "feste"
 
 ## Configuration
 
-Feste organizes subscribable emails by separating them into categories that you define (see <a href="#mailer">Mailer</a> for more details).  This requires an array of available category names to be provided to the `categories` configuration.
+Feste organizes subscribable emails by separating them into categories that you define (see <a href="#mailer">Mailer</a> for more details).  This requires an array of available categories (represented by symbols) to be provided to the `categories` configuration.
 
 Out of the box, Feste allows your users to manage their subscriptions from a url in their email, which includes an identifying token.  If you would like for them to be able to do so from within your application, you will need to provide a method for identifying the currently logged in user.  Luckily, Feste provides authentication adapters for applications that use Devise and Clearance to manage user sessions.  Otherwise, you can provide a Proc to the `authenticate_with` option.
 
@@ -37,7 +37,7 @@ end
 
 Feste.configure do |config|
   # set your category names
-  config.categories = []
+  config.categories = [:marketing_emails, :reminder_emails]
   # for applications that use clearance
   config.authenticate_with = :clearance
   # for applications that use devise
@@ -76,7 +76,7 @@ When calling the `mail` method within an action, make sure to explicitly state w
 class CouponMailer < ApplicationMailer
   include Feste::Mailer
 
-  categorize as: "Marketing Emails"
+  categorize as: :marketing_emails
 
   def send_coupon(user)
     mail(to: user.email, from: "support@here.com", subscriber: user)
@@ -90,8 +90,8 @@ If you only want to categorize specific actions in a mailer, you can do so by li
 class CouponMailer < ApplicationMailer
   include Feste::Mailer
 
-  categorize [:send_coupon], as: "Marketing Emails"
-  categorize [:send_coupon_reminder], as: "Reminder Emails"
+  categorize [:send_coupon], as: :marketing_emails
+  categorize [:send_coupon_reminder], as: :reminder_emails
 
   def send_coupon(user)
     mail(to: user.email, from: "support@here.com", subscriber: user)
@@ -118,6 +118,20 @@ When a user clicks this link, they are taken to a page that allows them to choos
 #### Application View
 
 The route to the subscriptions page is the root of the feste engine.  You can link to this page from anywhere in your app using the `feste.subscriptions_url` helper (assuming the engine is mounted as 'feste').  When a logged in user visits this page from your application, they will be authenticated through the method which you provide in the configuration, and shown their email subscriptions.
+
+### Human Readable Category Names
+
+In order to create category names that are human readable, add a `feste.categories`section to your i18n `locales` files.  Create keys in this section that correspond to the `categories` configuration.
+
+```yml
+# config/locales/en.yml
+
+en:
+  feste:
+    categories:
+      marketing_emails: Marketing Emails
+      reminder_emails: Reminder Emails
+```
 
 ### When not to use
 

--- a/app/models/feste/subscription.rb
+++ b/app/models/feste/subscription.rb
@@ -22,6 +22,10 @@ module Feste
       end&.find_by(Feste.options[:email_source] => email)
     end
 
+    def category_name
+      I18n.t("feste.categories.#{category}", default: category.titleize)
+    end
+
     private
 
     def self.user_models

--- a/app/views/feste/subscriptions/index.html.erb
+++ b/app/views/feste/subscriptions/index.html.erb
@@ -7,9 +7,9 @@
     <% @subscriber.subscriptions.order(category: :asc).each do |subscription| %>
       <div class="subscription-category-container">
         <%= label_tag do %>
-          <%= subscription_form.check_box(nil, {id: "subscription-#{subscription.category.parameterize}", checked: !subscription.canceled?}, subscription.id, nil) %>
+          <%= subscription_form.check_box(nil, {id: "subscription-#{subscription.category_name.parameterize}", checked: !subscription.canceled?}, subscription.id, nil) %>
           <span class="subscription-category-name">
-            <%= subscription.category %>
+            <%= subscription.category_name %>
           </span>
         <% end %>
       </div>

--- a/spec/dummy/app/mailers/marketing_mailer.rb
+++ b/spec/dummy/app/mailers/marketing_mailer.rb
@@ -1,7 +1,7 @@
 class MarketingMailer < ApplicationMailer
   include Feste::Mailer
 
-  categorize as: "Marketing Emails"
+  categorize as: :marketing_emails
 
   def send_newsletter(user)
     mail(to: user.email, from: "support@app.com", subscriber: user)

--- a/spec/dummy/app/mailers/outreach_mailer.rb
+++ b/spec/dummy/app/mailers/outreach_mailer.rb
@@ -1,7 +1,7 @@
 class OutreachMailer < ApplicationMailer
   include Feste::Mailer
 
-  categorize as: "Outreach Emails"
+  categorize as: :outreach_emails
 
   def request_donation(user)
     mail(to: user.email, from: "support@app.com", subscriber: user)

--- a/spec/dummy/app/mailers/reminder_mailer.rb
+++ b/spec/dummy/app/mailers/reminder_mailer.rb
@@ -1,7 +1,7 @@
 class ReminderMailer < ApplicationMailer
   include Feste::Mailer
 
-  categorize as: "Reminder Emails"
+  categorize as: :reminder_emails
 
   def send_reminder(user)
     mail(to: user.email, from: "support@app.com", subscriber: user)

--- a/spec/dummy/config/initializers/feste.rb
+++ b/spec/dummy/config/initializers/feste.rb
@@ -4,9 +4,9 @@ end
 
 Feste.configure do |config|
   config.categories = [
-    "Marketing Emails",
-    "Reminder Emails",
-    "Outreach Emails"
+    :marketing_emails,
+    :reminder_emails,
+    :outreach_emails
   ]
   config.authenticate_with = authentication_method
 end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -31,3 +31,8 @@
 
 en:
   hello: "Hello world"
+  feste:
+    categories:
+      marketing_emails: Marketing Emails
+      outreach_emails: Outreach Emails
+      reminder_emails: Reminder Emails

--- a/spec/dummy/spec/features/user_manages_email_subscriptions_spec.rb
+++ b/spec/dummy/spec/features/user_manages_email_subscriptions_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "user manages email subscriptions", js: true do
       subscription = create(
         :subscription,
         subscriber: user,
-        category: "Marketing Emails"
+        category: :marketing_emails
       )
 
       visit subscriptions_path(token: subscription.token)
@@ -35,7 +35,7 @@ RSpec.feature "user manages email subscriptions", js: true do
       subscription = create(
         :subscription,
         subscriber: user,
-        category: "Marketing Emails"
+        category: :marketing_emails
       ) 
 
       visit subscriptions_path(token: subscription.token)

--- a/spec/dummy/spec/features/user_visits_subscriptions_path_spec.rb
+++ b/spec/dummy/spec/features/user_visits_subscriptions_path_spec.rb
@@ -6,11 +6,11 @@ RSpec.feature "user visits subscriptions path" do
       scenario "and sees all subscribable mailers" do
         user = create(:user)
 
-        create(:subscription, subscriber: user, category: "Outreach Emails")
-        create(:subscription, subscriber: user, category: "Marketing Emails")
+        create(:subscription, subscriber: user, category: :outreach_emails)
+        create(:subscription, subscriber: user, category: :marketing_emails)
         subscription = create(:subscription, 
           subscriber: user,
-          category: "Reminder Emails",
+          category: :reminder_emails,
           canceled: true
         )
 
@@ -20,9 +20,9 @@ RSpec.feature "user visits subscriptions path" do
         marketing_checkbox = find("#subscription-marketing-emails")
         reminder_checkbox = find("#subscription-reminder-emails")
 
-        expect(page).to have_text("Outreach Emails")
-        expect(page).to have_text("Marketing Emails")
-        expect(page).to have_text("Reminder Emails")
+        expect(page).to have_text(I18n.t("feste.categories.marketing_emails"))
+        expect(page).to have_text(I18n.t("feste.categories.outreach_emails"))
+        expect(page).to have_text(I18n.t("feste.categories.reminder_emails"))
         
         expect(outreach_checkbox.checked?).to be true
         expect(marketing_checkbox.checked?).to be true
@@ -41,18 +41,13 @@ RSpec.feature "user visits subscriptions path" do
         marketing_checkbox = find("#subscription-marketing-emails")
         reminder_checkbox = find("#subscription-reminder-emails")  
 
-        expect(page).to have_text("Outreach Emails")
-        expect(page).to have_text("Marketing Emails")
-        expect(page).to have_text("Reminder Emails")
+        expect(page).to have_text(I18n.t("feste.categories.marketing_emails"))
+        expect(page).to have_text(I18n.t("feste.categories.outreach_emails"))
+        expect(page).to have_text(I18n.t("feste.categories.reminder_emails"))
         expect(outreach_checkbox.checked?).to be true
         expect(marketing_checkbox.checked?).to be true
         expect(reminder_checkbox.checked?).to be true    
       end
-    end
-  end
-
-  context "when she does not have a user record" do
-    scenario "and receives a 404 error" do
     end
   end
 end

--- a/spec/dummy/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/reminder_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ReminderMailer, type: :mailer do
         create(
           :subscription,
           canceled: true,
-          category: "Reminder Emails",
+          category: :reminder_emails,
           subscriber: user
         )
 
@@ -24,7 +24,7 @@ RSpec.describe ReminderMailer, type: :mailer do
         subscription = create(
           :subscription,
           canceled: false,
-          category: "Reminder Emails",
+          category: :reminder_emails,
           subscriber: user
         )
 

--- a/spec/dummy/spec/models/subscription_spec.rb
+++ b/spec/dummy/spec/models/subscription_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Feste::Subscription, type: :model do
         subscription = create(
           :subscription,
           subscriber: user,
-          category: "Reminder Emails"
+          category: :reminder_emails
         )
 
         token = Feste::Subscription.get_token_for(
@@ -37,7 +37,7 @@ RSpec.describe Feste::Subscription, type: :model do
 
         subscription = Feste::Subscription.find_by(
           subscriber: user,
-          category: "Reminder Emails"
+          category: :reminder_emails
         )
 
         expect(subscription.token).to eq(token)

--- a/spec/feste/mailer_spec.rb
+++ b/spec/feste/mailer_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Feste::Mailer do
   describe ".categorize" do
     it "adds all mailer actions to a category" do
       expect(MainMailer.action_categories[:send_mail]).
-        to eq("Marketing Emails")
+        to eq(:marketing_emails)
     end
 
     it "adds selected mailer actions to a category" do
       class TestMailer < ActionMailer::Base
         include Feste::Mailer
 
-        categorize [:test_action], as: "Marketing Emails"
+        categorize [:test_action], as: :marketing_emails
 
         def test_action(user)
           mail(to: user.email, from: "support@test.com")
@@ -23,7 +23,7 @@ RSpec.describe Feste::Mailer do
       end
 
       expect(TestMailer.action_categories[:test_action]).
-        to eq("Marketing Emails")
+        to eq(:marketing_emails)
       expect(TestMailer.action_categories[:ignore_action]).to be nil
     end
   end

--- a/spec/support/main_mailer.rb
+++ b/spec/support/main_mailer.rb
@@ -1,7 +1,7 @@
 class MainMailer < ActionMailer::Base
   include Feste::Mailer
 
-  categorize [:send_mail, :send_more_mail], as: "Marketing Emails"
+  categorize [:send_mail, :send_more_mail], as: :marketing_emails
 
   def send_mail(user)
     mail(


### PR DESCRIPTION
This PR allows users to change the human readable name of a category without updating the database by storing the category reference as a symbol that relates to an i18n key for the readable name.