### PR TITLE
allow developers to add event subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If you would like to create callbacks for when a user unsubscribes or resubscrib
 ```ruby
 # config/initializers/feste.rb
 
-class EventSubscriber
+class CallbackHandler
   def unsubscribe(event)
     # This method is called whenever a user unsubscribes from an mailing list they were previously subscribed to.
     event[:controller] # the instance of the controller
@@ -159,7 +159,7 @@ class EventSubscriber
 end
 
 Feste.configure do |config|
-  config.event_subscriber = EventSubscriber.new
+  config.callback_handler = CallbackHandler.new
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Feste.configure do |config|
   config.email_source = :email
   # set the host for subscription_url
   config.host = ActionMailer::Base.default_url_options[:host]
-  # set an event subscriber
-  config.event_subscriber = FesteEventSubscriber.new
+  # set callbacks
+  config.callback_handler = FesteCallbackHandler.new
 end
 ```
 ## Usage
@@ -139,12 +139,12 @@ en:
 
 It is recommended you DO NOT include any important emails, such as password reset emails, into a subscribable category.  It is also recommended you do not include the subscription link in any email that is sent to multiple recipients.  Though Feste comes with some security measures, it is assumed that each email is intended for only one recipient, and the `subscription_url` helper leads to a subsciption page meant only for that recipient.  Exposing this page to other users may allow them to change subscription preferences for someone else's account.
 
-## Event Subscribers
+## Callbacks
 
-If you would like to create callbacks for when a user unsubscribes or resubscribes to a mailing list, you can do so by creating an event subscriber.  Event subscribers should be objects with two instance methods: `unsubscribe` and `resubscribe`:
+If you would like to create callbacks for when a user unsubscribes or resubscribes to a mailing list, you can do so by creating a callback handler.  Callback handlers should be objects with two instance methods: `unsubscribe` and `resubscribe`.  You can register an instance of this object as your callback handler with the `callback_handler` configuration option.
 
 ```ruby
-# app/subscribers/event_subscriber.rb
+# config/initializers/feste.rb
 
 class EventSubscriber
   def unsubscribe(event)
@@ -157,12 +157,6 @@ class EventSubscriber
     # This method is called whenever a user subscribes to a mailing list they were previously unsubscribed to.
   end
 end
-```
-
-You can register an instance of this object as your event subscriber with the `event_subscriber` configuration option.
-
-```ruby
-# config/initializers/feste.rb
 
 Feste.configure do |config|
   config.event_subscriber = EventSubscriber.new

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Feste.configure do |config|
   config.email_source = :email
   # set the host for subscription_url
   config.host = ActionMailer::Base.default_url_options[:host]
+  # set an event subscriber
+  config.event_subscriber = FesteEventSubscriber.new
 end
 ```
 ## Usage
@@ -136,6 +138,36 @@ en:
 ### When not to use
 
 It is recommended you DO NOT include any important emails, such as password reset emails, into a subscribable category.  It is also recommended you do not include the subscription link in any email that is sent to multiple recipients.  Though Feste comes with some security measures, it is assumed that each email is intended for only one recipient, and the `subscription_url` helper leads to a subsciption page meant only for that recipient.  Exposing this page to other users may allow them to change subscription preferences for someone else's account.
+
+## Event Subscribers
+
+If you would like to create callbacks for when a user unsubscribes or resubscribes to a mailing list, you can do so by creating an event subscriber.  Event subscribers should be objects with two instance methods: `unsubscribe` and `resubscribe`:
+
+```ruby
+# app/subscribers/event_subscriber.rb
+
+class EventSubscriber
+  def unsubscribe(event)
+    # This method is called whenever a user unsubscribes from an mailing list they were previously subscribed to.
+    event[:controller] # the instance of the controller
+    event[:subscriber] # the user that unsubscribed
+  end
+
+  def resubscribe(event)
+    # This method is called whenever a user subscribes to a mailing list they were previously unsubscribed to/
+  end
+end
+```
+
+You can register an instance of this object as your event subscriber with the `event_subscriber` configuration option.
+
+```ruby
+# config/initializers/feste.rb
+
+Feste.configure do |config|
+  config.event_subscriber = EventSubscriber.new
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ class EventSubscriber
   end
 
   def resubscribe(event)
-    # This method is called whenever a user subscribes to a mailing list they were previously unsubscribed to/
+    # This method is called whenever a user subscribes to a mailing list they were previously unsubscribed to.
   end
 end
 ```

--- a/app/controllers/feste/subscriptions_controller.rb
+++ b/app/controllers/feste/subscriptions_controller.rb
@@ -11,7 +11,9 @@ module Feste
     end
 
     def update
+      events = set_subscribable_events
       if update_subscriptions
+        publish_subscribable_events(events)
         flash[:success] = "You have successfully updated your subscriptions!"
       else
         flash[:notice] = "Something went wrong!  Please try again later."
@@ -38,6 +40,54 @@ module Feste
         not(id: subscriptions_params)
       subscribed.update_all(canceled: false) && 
         unsubscribed.update_all(canceled: true)
+    end
+
+    def set_subscribable_events
+      events = []
+      if Feste.options[:event_subscriber].present?
+        events << unsubscribe_event if user_unsubscribing_from_emails?
+        events << resubscribe_event if user_resubscribing_to_emails?
+      end
+      events
+    end
+
+    def user_unsubscribing_from_emails?
+      subscription_ids = user_params[:subscriptions]&.map(&:to_i) || []
+      subscriber.subscriptions.where(canceled: false).pluck(:id).sort !=
+        subscription_ids.sort
+    end
+
+    def user_resubscribing_to_emails?
+      subscription_ids = user_params[:subscriptions]&.map(&:to_i) || []
+      subscriber.subscriptions.where(canceled: true).pluck(:id).any? do |id|
+        subscription_ids.include?(id)
+      end
+    end
+
+    def unsubscribe_event
+      {
+        name: :unsubscribe,
+        subscriber: subscriber,
+        controller: self
+      }
+    end
+
+    def resubscribe_event
+      {
+        name: :resubscribe,
+        subscriber: subscriber,
+        controller: self
+      }
+    end
+
+    def publish_subscribable_events(events)
+      if Feste.options[:event_subscriber].present?
+        events.each do |event|
+          if Feste.options[:event_subscriber].respond_to?(event[:name])
+            Feste.options[:event_subscriber].send(event[:name], event)
+          end
+        end
+      end
     end
   end
 end

--- a/app/controllers/feste/subscriptions_controller.rb
+++ b/app/controllers/feste/subscriptions_controller.rb
@@ -84,7 +84,7 @@ module Feste
       if Feste.options[:event_subscriber].present?
         events.each do |event|
           if Feste.options[:event_subscriber].respond_to?(event[:name])
-            Feste.options[:event_subscriber].send(event[:name], event)
+            Feste.options[:event_subscriber].public_send(event[:name], event)
           end
         end
       end

--- a/app/controllers/feste/subscriptions_controller.rb
+++ b/app/controllers/feste/subscriptions_controller.rb
@@ -11,9 +11,9 @@ module Feste
     end
 
     def update
-      events = set_subscribable_events
+      events = set_callback_events
       if update_subscriptions
-        publish_subscribable_events(events)
+        publish_callback_events(events)
         flash[:success] = "You have successfully updated your subscriptions!"
       else
         flash[:notice] = "Something went wrong!  Please try again later."
@@ -42,9 +42,9 @@ module Feste
         unsubscribed.update_all(canceled: true)
     end
 
-    def set_subscribable_events
+    def set_callback_events
       events = []
-      if Feste.options[:event_subscriber].present?
+      if Feste.options[:callback_handler].present?
         events << unsubscribe_event if user_unsubscribing_from_emails?
         events << resubscribe_event if user_resubscribing_to_emails?
       end
@@ -80,11 +80,11 @@ module Feste
       }
     end
 
-    def publish_subscribable_events(events)
-      if Feste.options[:event_subscriber].present?
+    def publish_callback_events(events)
+      if Feste.options[:callback_handler].present?
         events.each do |event|
-          if Feste.options[:event_subscriber].respond_to?(event[:name])
-            Feste.options[:event_subscriber].public_send(event[:name], event)
+          if Feste.options[:callback_handler].respond_to?(event[:name])
+            Feste.options[:callback_handler].public_send(event[:name], event)
           end
         end
       end

--- a/app/controllers/feste/subscriptions_controller.rb
+++ b/app/controllers/feste/subscriptions_controller.rb
@@ -53,8 +53,9 @@ module Feste
 
     def user_unsubscribing_from_emails?
       subscription_ids = user_params[:subscriptions]&.map(&:to_i) || []
-      subscriber.subscriptions.where(canceled: false).pluck(:id).sort !=
-        subscription_ids.sort
+      subscriber.subscriptions.where(canceled: false).pluck(:id).any? do |id|
+        !subscription_ids.include?(id)
+      end
     end
 
     def user_resubscribing_to_emails?

--- a/lib/feste.rb
+++ b/lib/feste.rb
@@ -22,7 +22,7 @@ module Feste
     host: nil,
     email_source: :email,
     authenticate_with: nil,
-    event_subscriber: nil
+    callback_handler: nil
   }
 
   def self.configure

--- a/lib/feste.rb
+++ b/lib/feste.rb
@@ -21,7 +21,8 @@ module Feste
     categories: [],
     host: nil,
     email_source: :email,
-    authenticate_with: nil
+    authenticate_with: nil,
+    event_subscriber: nil
   }
 
   def self.configure

--- a/lib/feste/version.rb
+++ b/lib/feste/version.rb
@@ -1,3 +1,3 @@
 module Feste
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end 

--- a/spec/controllers/feste/subscriptions_controller_spec.rb
+++ b/spec/controllers/feste/subscriptions_controller_spec.rb
@@ -42,18 +42,21 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
     context "when a user unsubscribes" do
       it "calls the unsubscribe event callback" do
         expect_any_instance_of(CallbackHandler).to receive(:unsubscribe)
+        expect_any_instance_of(CallbackHandler).not_to receive(:resubscribe)
 
         subscriber = create(:user)
         create_subscriptions_list_for(subscriber)
         token = subscriber.subscriptions.last.token
+        id = subscriber.subscriptions.last.id
 
-        put :update, params: { token: token, user: { subscriptions: "" } }
+        put :update, params: { token: token, user: { subscriptions: [id] } }
       end
     end
 
     context "when a user resubscribes" do
       it "calls the resubscribe event callback" do
         expect_any_instance_of(CallbackHandler).to receive(:resubscribe)
+        expect_any_instance_of(CallbackHandler).not_to receive(:unsubscribe)
 
         subscriber = create(:user)
         create_subscriptions_list_for(

--- a/spec/controllers/feste/subscriptions_controller_spec.rb
+++ b/spec/controllers/feste/subscriptions_controller_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
 
   describe "#update" do
     before do
-      class EventSubscriber
+      class CallbackHandler
         def unsubscribe(event); end
         def resubscribe(event); end
       end
 
       Feste.configure do |config|
-        config.event_subscriber = EventSubscriber.new
+        config.callback_handler = CallbackHandler.new
       end
     end
 
     after do
       Feste.configure do |config|
-        config.event_subscriber = nil
+        config.callback_handler = nil
       end
     end
 
@@ -40,8 +40,8 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
     end
 
     context "when a user unsubscribes" do
-      it "calls the unsubscribe event subscriber" do
-        expect_any_instance_of(EventSubscriber).to receive(:unsubscribe)
+      it "calls the unsubscribe event callback" do
+        expect_any_instance_of(CallbackHandler).to receive(:unsubscribe)
 
         subscriber = create(:user)
         create_subscriptions_list_for(subscriber)
@@ -52,8 +52,8 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
     end
 
     context "when a user resubscribes" do
-      it "calls the resubscribe event subscriber" do
-        expect_any_instance_of(EventSubscriber).to receive(:resubscribe)
+      it "calls the resubscribe event callback" do
+        expect_any_instance_of(CallbackHandler).to receive(:resubscribe)
 
         subscriber = create(:user)
         create_subscriptions_list_for(
@@ -71,9 +71,9 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
     end
 
     context "when a user resubscribes and unsubscribes" do
-      it "calls the unsubscribe and resubscribe event subscribers" do
-        expect_any_instance_of(EventSubscriber).to receive(:unsubscribe)
-        expect_any_instance_of(EventSubscriber).to receive(:resubscribe)
+      it "calls the unsubscribe and resubscribe event callbacks" do
+        expect_any_instance_of(CallbackHandler).to receive(:unsubscribe)
+        expect_any_instance_of(CallbackHandler).to receive(:resubscribe)
 
         subscriber = create(:user)
         create_subscriptions_list_for(subscriber)

--- a/spec/controllers/feste/subscriptions_controller_spec.rb
+++ b/spec/controllers/feste/subscriptions_controller_spec.rb
@@ -14,12 +14,87 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
   end
 
   describe "#update" do
+    before do
+      class EventSubscriber
+        def unsubscribe(event); end
+        def resubscribe(event); end
+      end
+
+      Feste.configure do |config|
+        config.event_subscriber = EventSubscriber.new
+      end
+    end
+
+    after do
+      Feste.configure do |config|
+        config.event_subscriber = nil
+      end
+    end
+
     context "when being accessed without a token" do
       it "returns a 404 resopnse to unauthroized users" do
-        put :update, params: { user: { subscriptions: [] } }
+        put :update, params: { user: { subscriptions: "" } }
 
         expect(response.status).to eq 404
       end
+    end
+
+    context "when a user unsubscribes" do
+      it "triggers the unsubscribe listener" do
+        expect_any_instance_of(EventSubscriber).to receive(:unsubscribe)
+
+        subscriber = create(:user)
+        create_subscriptions_list_for(subscriber)
+        token = subscriber.subscriptions.last.token
+
+        put :update, params: { token: token, user: { subscriptions: "" } }
+      end
+    end
+
+    context "when a user resubscribes" do
+      it "triggers the resubscribe listener" do
+        expect_any_instance_of(EventSubscriber).to receive(:resubscribe)
+
+        subscriber = create(:user)
+        create_subscriptions_list_for(
+          subscriber,
+          canceled: true
+        )
+        subscription_ids = subscriber.subscriptions.map(&:id)
+        token = subscriber.subscriptions.last.token
+
+        put(
+          :update,
+          params: { token: token, user: { subscriptions: subscription_ids } }
+        )
+      end
+    end
+
+    context "when a user resubscribes and unsubscribes" do
+      it "sends the unsubscribe and resubscribe " do
+        expect_any_instance_of(EventSubscriber).to receive(:unsubscribe)
+        expect_any_instance_of(EventSubscriber).to receive(:resubscribe)
+
+        subscriber = create(:user)
+        create_subscriptions_list_for(subscriber)
+        subscriber.subscriptions.first.update(canceled: true)
+        sub_ids = [
+          subscriber.subscriptions.where(canceled: false).first.id,
+          subscriber.subscriptions.where(canceled: true).first.id
+        ]
+        token = subscriber.subscriptions.last.token
+
+        put :update, params: { token: token, user: { subscriptions: sub_ids } }
+      end
+    end
+  end
+
+  def create_subscriptions_list_for(subscriber, options = {})
+    Feste.options[:categories].map do |cat|
+      create(
+        :subscription,
+        { subscriber: subscriber, category: cat }.merge(options)
+      )
     end
   end
 end

--- a/spec/controllers/feste/subscriptions_controller_spec.rb
+++ b/spec/controllers/feste/subscriptions_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
     end
 
     context "when a user unsubscribes" do
-      it "triggers the unsubscribe listener" do
+      it "calls the unsubscribe event subscriber" do
         expect_any_instance_of(EventSubscriber).to receive(:unsubscribe)
 
         subscriber = create(:user)
@@ -52,7 +52,7 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
     end
 
     context "when a user resubscribes" do
-      it "triggers the resubscribe listener" do
+      it "calls the resubscribe event subscriber" do
         expect_any_instance_of(EventSubscriber).to receive(:resubscribe)
 
         subscriber = create(:user)
@@ -71,7 +71,7 @@ RSpec.describe Feste::SubscriptionsController, type: :controller do
     end
 
     context "when a user resubscribes and unsubscribes" do
-      it "sends the unsubscribe and resubscribe " do
+      it "calls the unsubscribe and resubscribe event subscribers" do
         expect_any_instance_of(EventSubscriber).to receive(:unsubscribe)
         expect_any_instance_of(EventSubscriber).to receive(:resubscribe)
 

--- a/spec/dummy/spec/features/user_visits_subscriptions_path_spec.rb
+++ b/spec/dummy/spec/features/user_visits_subscriptions_path_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "user visits subscriptions path" do
       end
     end
     
-    context "when she visit without a token" do
+    context "when she visits without a token" do
       scenario "and sees all subscribable mailers" do
         user = create(:user)
         inject_session(user_id: user.id)


### PR DESCRIPTION
This PR allows developers to create event subscribers, which register callbacks for when a user unsubscribes or resubscribes.  By creating an object that responds to methods `unsubscribe` and `resubscribe`, developers can perform some action when one of these events happens.  These events are triggered when a valid request is sent to `Feste::SubscriptionsConrtoller#update`, after the subscriber has been updated.  Event subscriber methods are given a hash as an argument that gives developers access to the controller instance, `event[:controller]` and the subscriber `event[:subscriber]`.  Developers can use this data to perform some task before the request completes as normal.