### PR TITLE
Make Feste Sprockets 4 Compatible

### DIFF
--- a/lib/feste/engine.rb
+++ b/lib/feste/engine.rb
@@ -10,9 +10,7 @@ module Feste
     end
 
     initializer "feste" do |app|
-      app.config.assets.precompile << proc do |path| 
-        path =~ /\Afeste\/application\.(js|css)\z/
-      end
+      app.config.assets.precompile += %w(feste/application.css feste/application.js)
     end
   end
 end

--- a/lib/feste/version.rb
+++ b/lib/feste/version.rb
@@ -1,3 +1,3 @@
 module Feste
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end 


### PR DESCRIPTION
Sprockets 4 is deprecating the ability to add precompiled assets through the use of procs.  Instead, since there are only two files being added, we should list them in an array to be added to the main application's precompiled assets.