### PR TITLE
Avoid removed add_templat_helper method

### DIFF
--- a/lib/feste/mailer.rb
+++ b/lib/feste/mailer.rb
@@ -3,7 +3,8 @@ module Feste
     def self.included(klass)
       klass.include InstanceMethods
       klass.extend ClassMethods
-      klass.send(:add_template_helper, TemplateHelper)
+      klass.include TemplateHelper
+      klass.helper TemplateHelper
       klass.class_eval do
         class_attribute :action_categories
         self.action_categories = {}


### PR DESCRIPTION
Hey @jereinhardt hope you're well!

Feste uses `add_template_helper`, which was removed in Rails 6.1 and was apparently not supposed to be used in the first place. This PR uses the documented (though poorly documented) method of adding a helper to a mailer and making it accessible from both the mailer and the views.

I couldn't actually install the dependencies to get tests running, but my fork seems to work locally. No need to keep maintaining this if you aren't using it anywhere else, but I figured I'd open a PR just in case it's helpful.